### PR TITLE
zuul: re-enable build of old images

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -46,6 +46,27 @@
     timeout: 1800
 
 - job:
+    name: openstack-octavia-amphora-image-build-2023.1
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2023.1"
+      upload_image: false
+
+- job:
+    name: openstack-octavia-amphora-image-build-2023.2
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2023.2"
+      upload_image: false
+
+- job:
+    name: openstack-octavia-amphora-image-build-2024.1
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2024.1"
+      upload_image: false
+
+- job:
     name: openstack-octavia-amphora-image-build-2024.2
     parent: openstack-octavia-amphora-image-build
     vars:
@@ -65,6 +86,45 @@
     vars:
       version_openstack: "2025.2"
       upload_image: false
+
+- job:
+    name: openstack-octavia-amphora-image-publish-2023.1
+    semaphores:
+      - name: semaphore-openstack-octavia-amphora-image-publish
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2023.1"
+      upload_image: true
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
+        pass-to-parent: true
+
+- job:
+    name: openstack-octavia-amphora-image-publish-2023.2
+    semaphores:
+      - name: semaphore-openstack-octavia-amphora-image-publish
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2023.2"
+      upload_image: true
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
+        pass-to-parent: true
+
+- job:
+    name: openstack-octavia-amphora-image-publish-2024.1
+    semaphores:
+      - name: semaphore-openstack-octavia-amphora-image-publish
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2024.1"
+      upload_image: true
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
+        pass-to-parent: true
 
 - job:
     name: openstack-octavia-amphora-image-publish-2024.2
@@ -110,18 +170,30 @@
     default-branch: main
     check:
       jobs:
+        - openstack-octavia-amphora-image-build-2023.1
+        - openstack-octavia-amphora-image-build-2023.2
+        - openstack-octavia-amphora-image-build-2024.1
         - openstack-octavia-amphora-image-build-2024.2
         - openstack-octavia-amphora-image-build-2025.1
         - openstack-octavia-amphora-image-build-2025.2
     periodic-daily:
       jobs:
         - openstack-octavia-amphora-image-cleanup
+        - openstack-octavia-amphora-image-publish-2023.1
+        - openstack-octavia-amphora-image-publish-2023.2
+        - openstack-octavia-amphora-image-publish-2024.1
         - openstack-octavia-amphora-image-publish-2024.2
         - openstack-octavia-amphora-image-publish-2025.1
         - openstack-octavia-amphora-image-publish-2025.2
     post:
       jobs:
         - openstack-octavia-amphora-image-cleanup:
+            branches: main
+        - openstack-octavia-amphora-image-publish-2023.1:
+            branches: main
+        - openstack-octavia-amphora-image-publish-2023.2:
+            branches: main
+        - openstack-octavia-amphora-image-publish-2024.1:
             branches: main
         - openstack-octavia-amphora-image-publish-2024.2:
             branches: main

--- a/README.md
+++ b/README.md
@@ -1,38 +1,34 @@
 # OpenStack Octavia Amphora Image
 
-## Current images
-
 The images are rebuilt every day. Images with a `YYYYMMDD` marker (e.g. `octavia-amphora-haproxy-zed.20240304.qcow2`)
 are also available for the last 30 days. The last available image of this type can be retrieved in a file `last-VERSION` (e.g. `last-zed`).
 
-### 2025.2 (Flamingo)
+## 2025.2 (Flamingo)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.2.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.2.qcow2.CHECKSUM
 
-### 2025.1 (Expoxy)
+## 2025.1 (Expoxy)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.1.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.1.qcow2.CHECKSUM
 
-### 2024.2 (Dalmatian)
+## 2024.2 (Dalmatian)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.2.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.2.qcow2.CHECKSUM
 
-## Archived images
-
-### 2024.1 (Caracal)
+## 2024.1 (Caracal)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.1.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.1.qcow2.CHECKSUM
 
-### 2023.2 (Bobcat)
+## 2023.2 (Bobcat)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2023.2.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2023.2.qcow2.CHECKSUM
 
-### 2023.1 (Antelope)
+## 2023.1 (Antelope)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2023.1.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2023.1.qcow2.CHECKSUM

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -28,6 +28,12 @@
 
           pushd octavia/diskimage-create
 
+          if [[ "$VERSION" == "2023.1" ]]; then
+              git branch stable/$VERSION tags/2023.1-eom
+          elif [[ "$VERSION" == "2023.2" ]]; then
+              git branch stable/$VERSION tags/13.0.1
+          fi
+
           bash diskimage-create.sh \
               -a amd64 \
               -b haproxy \

--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -13,6 +13,27 @@
           ./mc alias set minio https://nbg1.your-objectstorage.com {{ secret.ACCESS_KEY | trim }} {{ secret.SECRET_KEY | trim }}
       no_log: true
 
+    - name: Cleanup 2023.1 images
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          ./mc find minio/osism/openstack-octavia-amphora-image/ --older-than 14d --regex "octavia-amphora-haproxy-2023\.1\.*\.\d*\.qcow2" --exec "./mc rm {}"
+
+    - name: Cleanup 2023.2 images
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          ./mc find minio/osism/openstack-octavia-amphora-image/ --older-than 14d --regex "octavia-amphora-haproxy-2023\.2\.*\.\d*\.qcow2" --exec "./mc rm {}"
+
+    - name: Cleanup 2024.1 images
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          ./mc find minio/osism/openstack-octavia-amphora-image/ --older-than 14d --regex "octavia-amphora-haproxy-2024\.1\.*\.\d*\.qcow2" --exec "./mc rm {}"
+
     - name: Cleanup 2024.2 images
       ansible.builtin.shell:
         executable: /bin/bash


### PR DESCRIPTION
A lot of people out there use old OpenStack versions. Let's provide them up to date amphora images.