### PR TITLE
Install rclone from rclone.org instead of distro packages

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -51,9 +51,9 @@
 
     - name: Install rclone
       become: true
-      ansible.builtin.package:
-        name: rclone
-        state: present
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: curl https://rclone.org/install.sh | bash
       when: upload_image | bool
 
     - name: Run upload

--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -5,10 +5,9 @@
   tasks:
     - name: Install rclone
       become: true
-      ansible.builtin.apt:
-        name: rclone
-        state: present
-        update_cache: true
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: curl https://rclone.org/install.sh | bash
 
     - name: Cleanup 2024.2 images
       ansible.builtin.shell:


### PR DESCRIPTION
The Ubuntu Jammy rclone package is too old to properly apply public-read ACLs with the Ceph S3 provider. Install the latest version from rclone.org/install.sh to fix 403 on uploaded objects.

AI-assisted: Claude Code