### PR TITLE
Drop 2024.2 builds

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -46,13 +46,6 @@
     timeout: 1800
 
 - job:
-    name: openstack-octavia-amphora-image-build-2024.2
-    parent: openstack-octavia-amphora-image-build
-    vars:
-      version_openstack: "2024.2"
-      upload_image: false
-
-- job:
     name: openstack-octavia-amphora-image-build-2025.1
     parent: openstack-octavia-amphora-image-build
     vars:
@@ -65,19 +58,6 @@
     vars:
       version_openstack: "2025.2"
       upload_image: false
-
-- job:
-    name: openstack-octavia-amphora-image-publish-2024.2
-    semaphores:
-      - name: semaphore-openstack-octavia-amphora-image-publish
-    parent: openstack-octavia-amphora-image-build
-    vars:
-      version_openstack: "2024.2"
-      upload_image: true
-    secrets:
-      - name: secret
-        secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
-        pass-to-parent: true
 
 - job:
     name: openstack-octavia-amphora-image-publish-2025.1
@@ -110,20 +90,16 @@
     default-branch: main
     check:
       jobs:
-        - openstack-octavia-amphora-image-build-2024.2
         - openstack-octavia-amphora-image-build-2025.1
         - openstack-octavia-amphora-image-build-2025.2
     periodic-daily:
       jobs:
         - openstack-octavia-amphora-image-cleanup
-        - openstack-octavia-amphora-image-publish-2024.2
         - openstack-octavia-amphora-image-publish-2025.1
         - openstack-octavia-amphora-image-publish-2025.2
     post:
       jobs:
         - openstack-octavia-amphora-image-cleanup:
-            branches: main
-        - openstack-octavia-amphora-image-publish-2024.2:
             branches: main
         - openstack-octavia-amphora-image-publish-2025.1:
             branches: main

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 ## Current images
 
 The images are rebuilt every day. Images with a `YYYYMMDD` marker (e.g. `octavia-amphora-haproxy-zed.20240304.qcow2`)
-are also available for the last 30 days. The last available image of this type can be retrieved in a file `last-VERSION` (e.g. `last-zed`).
+are also available for the last 14 days. The last available image of this type can be retrieved in a file `last-VERSION` (e.g. `last-zed`).
 
 ### 2025.2 (Flamingo)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.2.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.2.qcow2.CHECKSUM
 
-### 2025.1 (Expoxy)
+### 2025.1 (Epoxy)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.1.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.1.qcow2.CHECKSUM
+
+## Archived images
 
 ### 2024.2 (Dalmatian)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.2.qcow2
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2024.2.qcow2.CHECKSUM
-
-## Archived images
 
 ### 2024.1 (Caracal)
 

--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -9,21 +9,6 @@
         executable: /bin/bash
         cmd: curl https://rclone.org/install.sh | bash
 
-    - name: Cleanup 2024.2 images
-      ansible.builtin.shell:
-        executable: /bin/bash
-        cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2024.2.*.qcow2"
-      environment:
-        RCLONE_CONFIG_S3_TYPE: s3
-        RCLONE_CONFIG_S3_PROVIDER: Ceph
-        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
-        RCLONE_CONFIG_S3_REGION: nbg1
-        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
-        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
-        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
-      no_log: true
-
     - name: Cleanup 2025.1 images
       ansible.builtin.shell:
         executable: /bin/bash


### PR DESCRIPTION
The stable/2024.2 branch is EOL, stop building images for it.