### PR TITLE
Add 2026.1 image

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -60,6 +60,13 @@
       upload_image: false
 
 - job:
+    name: openstack-octavia-amphora-image-build-2026.1
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2026.1"
+      upload_image: false
+
+- job:
     name: openstack-octavia-amphora-image-publish-2025.1
     semaphores:
       - name: semaphore-openstack-octavia-amphora-image-publish
@@ -85,6 +92,19 @@
         secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
         pass-to-parent: true
 
+- job:
+    name: openstack-octavia-amphora-image-publish-2026.1
+    semaphores:
+      - name: semaphore-openstack-octavia-amphora-image-publish
+    parent: openstack-octavia-amphora-image-build
+    vars:
+      version_openstack: "2026.1"
+      upload_image: true
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_OCTAVIA_AMPHORA_IMAGE
+        pass-to-parent: true
+
 - project:
     merge-mode: squash-merge
     default-branch: main
@@ -92,11 +112,13 @@
       jobs:
         - openstack-octavia-amphora-image-build-2025.1
         - openstack-octavia-amphora-image-build-2025.2
+        - openstack-octavia-amphora-image-build-2026.1
     periodic-daily:
       jobs:
         - openstack-octavia-amphora-image-cleanup
         - openstack-octavia-amphora-image-publish-2025.1
         - openstack-octavia-amphora-image-publish-2025.2
+        - openstack-octavia-amphora-image-publish-2026.1
     post:
       jobs:
         - openstack-octavia-amphora-image-cleanup:
@@ -104,4 +126,6 @@
         - openstack-octavia-amphora-image-publish-2025.1:
             branches: main
         - openstack-octavia-amphora-image-publish-2025.2:
+            branches: main
+        - openstack-octavia-amphora-image-publish-2026.1:
             branches: main

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 The images are rebuilt every day. Images with a `YYYYMMDD` marker (e.g. `octavia-amphora-haproxy-zed.20240304.qcow2`)
 are also available for the last 14 days. The last available image of this type can be retrieved in a file `last-VERSION` (e.g. `last-zed`).
 
+### 2026.1 (Gazpacho)
+
+* https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2026.1.qcow2
+* https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2026.1.qcow2.CHECKSUM
+
 ### 2025.2 (Flamingo)
 
 * https://nbg1.your-objectstorage.com/osism/openstack-octavia-amphora-image/octavia-amphora-haproxy-2025.2.qcow2


### PR DESCRIPTION
Adding support for Amphora image in OpenStack 2026.1 (Gazpacho).

Commit https://github.com/osism/openstack-octavia-amphora-image/commit/b87eeedee639a0bfc8aa40b7b74892d8538fff02 was taken as reference. Thanks to @jklare 