### PR TITLE
Also clean up dated CHECKSUM files in cleanup playbook

### DIFF
--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -13,7 +13,7 @@
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.1.*.qcow2"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.1.*.qcow2*"
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph
@@ -28,7 +28,7 @@
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.2.*.qcow2"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.2.*.qcow2*"
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph
@@ -43,7 +43,7 @@
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2026.1.*.qcow2"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2026.1.*.qcow2*"
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph


### PR DESCRIPTION
## Problem

The cleanup playbook only deleted dated `*.qcow2` images older than 14 days, but **not** their `*.qcow2.CHECKSUM` siblings — so those accumulated indefinitely.

Verified directly against the bucket (today 2026-06-26, 14d cutoff 2026-06-12):

| Build date | `*.qcow2` | `*.qcow2.CHECKSUM` |
|------------|-----------|--------------------|
| 2026-06-13 … 26 (< 14d) | present | present |
| 2026-06-11 and older | **deleted ✓** | **still present ✗** (back to May 2026 and earlier) |

## Cause

The `--include "octavia-amphora-haproxy-<version>.*.qcow2"` filter only matches files *ending* in `.qcow2`. The dated checksums are named `...<version>.<date>.qcow2.CHECKSUM` (uploaded by `build.yml`), so they were never matched. The `--min-age 14d` logic itself is correct — the qcow2 deletion proves it.

## Fix

Widen the include pattern from `*.qcow2` to `*.qcow2*` in all three cleanup tasks (2025.1 / 2025.2 / 2026.1).

Tested locally with real `rclone delete --dry-run`: now deletes the dated qcow2 **and** its CHECKSUM, while still preserving the undated "latest" files (`...<version>.qcow2`, `...<version>.qcow2.CHECKSUM`) and the `last-<version>` pointer. The next daily `periodic-daily` run will clear the backlog automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)