### PR TITLE
Stop hiding rclone output in the cleanup job

### DIFF
--- a/playbooks/cleanup.yml
+++ b/playbooks/cleanup.yml
@@ -9,47 +9,50 @@
         executable: /bin/bash
         cmd: curl https://rclone.org/install.sh | bash
 
+    - name: Write the rclone configuration with the object-storage credentials
+      ansible.builtin.copy:
+        dest: "{{ ansible_user_dir }}/.rclone.conf"
+        mode: "0600"
+        content: |
+          [s3]
+          type = s3
+          provider = Ceph
+          endpoint = https://nbg1.your-objectstorage.com
+          region = nbg1
+          access_key_id = {{ secret.ACCESS_KEY | trim }}
+          secret_access_key = {{ secret.SECRET_KEY | trim }}
+          no_check_bucket = true
+      no_log: true
+
     - name: Cleanup 2025.1 images
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.1.*.qcow2*"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ \
+            --min-age 14d \
+            --include "octavia-amphora-haproxy-2025.1.*.qcow2*" \
+            -v --stats 30s --stats-one-line
       environment:
-        RCLONE_CONFIG_S3_TYPE: s3
-        RCLONE_CONFIG_S3_PROVIDER: Ceph
-        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
-        RCLONE_CONFIG_S3_REGION: nbg1
-        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
-        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
-        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
-      no_log: true
+        RCLONE_CONFIG: "{{ ansible_user_dir }}/.rclone.conf"
 
     - name: Cleanup 2025.2 images
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2025.2.*.qcow2*"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ \
+            --min-age 14d \
+            --include "octavia-amphora-haproxy-2025.2.*.qcow2*" \
+            -v --stats 30s --stats-one-line
       environment:
-        RCLONE_CONFIG_S3_TYPE: s3
-        RCLONE_CONFIG_S3_PROVIDER: Ceph
-        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
-        RCLONE_CONFIG_S3_REGION: nbg1
-        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
-        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
-        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
-      no_log: true
+        RCLONE_CONFIG: "{{ ansible_user_dir }}/.rclone.conf"
 
     - name: Cleanup 2026.1 images
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
-          rclone delete s3:osism/openstack-octavia-amphora-image/ --min-age 14d --include "octavia-amphora-haproxy-2026.1.*.qcow2*"
+          rclone delete s3:osism/openstack-octavia-amphora-image/ \
+            --min-age 14d \
+            --include "octavia-amphora-haproxy-2026.1.*.qcow2*" \
+            -v --stats 30s --stats-one-line
       environment:
-        RCLONE_CONFIG_S3_TYPE: s3
-        RCLONE_CONFIG_S3_PROVIDER: Ceph
-        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
-        RCLONE_CONFIG_S3_REGION: nbg1
-        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
-        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
-        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
-      no_log: true
+        RCLONE_CONFIG: "{{ ansible_user_dir }}/.rclone.conf"


### PR DESCRIPTION
`openstack-octavia-amphora-image-cleanup` timed out on 2026-09-02, and the log
cannot say why.

`playbooks/cleanup.yml` is three sequential `rclone delete` calls sharing the
30-minute budget the job inherits from `base`. On 2026-09-02 the 2025.1 delete
ran 24m46s of it and the timeout landed inside the 2025.2 delete. Nothing
failed — the first call simply ate the budget.

| task | duration |
|---|---|
| Install rclone | 3s |
| Cleanup 2025.1 images | **24m46s** (03:07:25 → 03:32:11) |
| Cleanup 2025.2 images | started 03:32:11, killed at 03:37:00 |
| Cleanup 2026.1 images | never ran |

All three tasks set `no_log: true`, because the S3 credentials ride in
`environment:` as `RCLONE_CONFIG_S3_*`. That also discards rclone's output, so
the only trace of a 25-minute delete is:

```
| Output suppressed because no_log was given
```

The CI node itself was fine: the `diagnose-network` probes ran before
(03:07:09) and after (03:37:01) the run and both show clean DNS and 200s in
0.2–0.4s over v4 and v6. Object volume is not it either — the job publishes ~2
dated objects per release per day and drops `--min-age 14d`. That points at the
nbg1 endpoint, but nothing in the build can confirm it.

This is not a one-off. The same shape occurred on 2026-03-05 (30m16s: 17m02s on
the first delete, 11m04s on the second, third killed) — inside a
[confirmed Hetzner nbg1 degradation](https://status.hetzner.com/incident/4b258cea-4323-4919-90d7-ee87b71520aa),
01:43–03:44 UTC that day, *"Requests may fail or time out."*

### What this changes

Only one thing: **stop hiding rclone's output.**

Write the credentials to a `0600` `.rclone.conf` from a `no_log` task and point
`RCLONE_CONFIG` at it; the delete tasks then run without `no_log`. The secret
never reaches a task that produces output. This is the pattern already in use in
[`osism/k8s-capi-images`](https://github.com/osism/k8s-capi-images/blob/main/playbooks/build.yml)
and
[`osism/zuul-config`](https://github.com/osism/zuul-config/blob/main/playbooks/publishing/publish-docs.yaml)
— this PR converges on it rather than inventing anything.

Also adds `-v --stats 30s --stats-one-line`, so a stalled transfer shows up in
the live console stream instead of only as a gap between two `TASK` lines.

### What this deliberately does not change

**The job's `timeout:`.** Raising it, or collapsing the three deletes into one
invocation so they stop sharing a budget, are both worth doing — but not before
there is evidence about what the delete is waiting on. This PR is what produces
that evidence.

**`--use-server-modtime`.** This PR originally carried it as a second commit and
it has been dropped. rclone keeps the modtime in `X-Amz-Meta-Mtime`, and per the
[S3 docs](https://rclone.org/s3/) *"reading this from the object takes an
additional HEAD request as the metadata isn't returned in object listings"* — so
`--min-age` costs roughly 90 HEADs per run today. Sampling the published objects
by hand shows the flag would be safe and near-neutral here: `Last-Modified` and
`x-amz-meta-mtime` agree to within ~2.5 minutes (the upload duration), which is
nothing against a 14-day threshold.

| object | `Last-Modified` | `x-amz-meta-mtime` | delta |
|---|---|---|---|
| `2025.1.20260901.qcow2` | 2026-09-01 03:28:53 | 2026-09-01 03:26:24 | +2.5 min |
| `2025.1.20260825.qcow2` | 2026-08-25 03:27:56 | 2026-08-25 03:25:30 | +2.4 min |

But that was measured with `HEAD`, and `--use-server-modtime` reads
`Last-Modified` out of the `ListObjectsV2` response, which needs credentials to
observe. It is an untested change to the one line that decides which objects get
deleted, on an endpoint whose S3 conformance has bitten this repo four times
(#136, #137, #138, #139 — two of them reverting the one before). Ninety HEAD
requests are seconds on a healthy backend; the theory that they matter on a
degraded one is speculation. Once the logging in this PR is live, the next slow
run will show whether HEADs are where the time actually goes, and the flag can
be added on measurement instead of inference.

### Testing

The `check` pipeline for this repo runs only the three
`openstack-octavia-amphora-image-build-*` jobs, none of which execute
`cleanup.yml`. Green CI here does **not** exercise this change; the real
verification is the next `periodic-daily` run. `ansible-lint` reports no new
findings (the pre-existing `no-changed-when` warnings on the shell tasks are
unchanged in number).